### PR TITLE
Textbook: 0.1: Corrected typo and changed comma after function definitions in exercises 8-13

### DIFF
--- a/public/textbook/functions.tex
+++ b/public/textbook/functions.tex
@@ -314,37 +314,37 @@ If $x$ were one of $-1$, $-3$, $5$, or $8$.
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) = 18x^5-27x^4-32x^3+11x^2 -7x +4$, evaluate $f(0)$.
+\begin{exercise} Let $f(x) = 18x^5-27x^4-32x^3+11x^2 -7x +4$. Evaluate $f(0)$.
 \begin{answer}
 $4$
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) = x^5+2x^4+3x^3+4x^2+5x+6$, evaluate $f(1)$.
+\begin{exercise} Let $f(x) = x^5+2x^4+3x^3+4x^2+5x+6$. Evaluate $f(1)$.
 \begin{answer}
 $21$
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) = x^5+2x^4+3x^3+4x^2+5x+6$, evaluate $f(-1)$.
+\begin{exercise} Let $f(x) = x^5+2x^4+3x^3+4x^2+5x+6$. Evaluate $f(-1)$.
 \begin{answer}
 $3$
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) =\sqrt{x^2+x+1}$, evaluate $f(w)$.
+\begin{exercise} Let $f(x) =\sqrt{x^2+x+1}$. Evaluate $f(w)$.
 \begin{answer}
 $\sqrt{w^2+w+1}$
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) =\sqrt{x^2+x+1}$, evaluate $f(x+h)$.
+\begin{exercise} Let $f(x) =\sqrt{x^2+x+1}$. Evaluate $f(x+h)$.
 \begin{answer}
 $\sqrt{(x+h)^2+(x+h)+1}$
 \end{answer}
 \end{exercise}
 
-\begin{exercise} Let $f(x) = \sqrt{x^2+x+1}$, evaluate $f(x+h) - f(x)$.
+\begin{exercise} Let $f(x) = \sqrt{x^2+x+1}$. Evaluate $f(x+h) - f(x)$.
 \begin{answer}
 $\sqrt{(x+h)^2+(x+h)+1} - \sqrt{x^2+x+1}$
 \end{answer}


### PR DESCRIPTION
The wordage in exercises 8-13 didn't work. If these were something like "Given f(x) = …, evaluate ….", it would make more sense. Instead of changing the wordage, I have opted to retain the "Let" definitions and make "evaluate …" full sentences.
