### PR TITLE
Week 2- limitsAtInfinityGraphical: Add label steps to graphs 

### DIFF
--- a/public/khan-exercises/exercises/limitsAtInfinityGraphical.html
+++ b/public/khan-exercises/exercises/limitsAtInfinityGraphical.html
@@ -197,7 +197,7 @@
                 	graphInit({
                         range: [20,10],
                         scale: [12,20],
-                      //  labelStep: [2,1],
+                        labelStep: [2,1],
                         gridOpacity: 0,
                         
                     });
@@ -263,7 +263,7 @@
                 	graphInit({
                         range: [20,10],
                         scale: [12,20],
-                      //  labelStep: [2,1],
+                        labelStep: [2,1],
                         gridOpacity: 0,
                        
                     });
@@ -341,7 +341,7 @@
                 	graphInit({
                         range: [20,10],
                         scale: [12,20],
-                       // labelStep: [2,1],
+                        labelStep: [2,1],
                         gridOpacity: 0,
 
                     });


### PR DESCRIPTION
The step labels were commented out on some exercises, which is fine when the answer trends toward infinity, but not so much when the point hits the third hash mark and the grader expects the numeral six, for example.

Perhaps there was a larger reason at play for those steps being commented out, so I send this as a separate pull request in case this is not the simple oversight it seems to be.
