### PR TITLE
Correct definition of p(t) in Figure 8.4 caption.

### DIFF
--- a/public/textbook/applicationsOfDifferentiation.tex
+++ b/public/textbook/applicationsOfDifferentiation.tex
@@ -714,7 +714,7 @@ What rate is the population growing at 20 hours?
           \addplot [very thick, penColor, smooth] {120*2^(3*x)};
         \end{axis}
 \end{tikzpicture}
-\caption{Here we see a plot of $p(t) = 120\cdot 2^{3x}$. Note, time is on
+\caption{Here we see a plot of $p(t) = 120\cdot 2^{3t}$. Note, time is on
   the $t$-axis and population is on the $p$-axis.}
 \end{marginfigure}
 


### PR DESCRIPTION
The caption referenced the variable x rather than t. 
