### PR TITLE
Fixed l_1(x) equation in Newton's method section.

### DIFF
--- a/public/textbook/linearApproximation.tex
+++ b/public/textbook/linearApproximation.tex
@@ -471,7 +471,7 @@ f(a_1) \approx 23.5.
 We see our new guess is better than our first. If we look at the
 linear approximation of $f(x)$ at $x=a_1$, we find
 \[
-\l_1(x) = f'(a_0)(x-a_0) + f(a_0).
+\l_1(x) = f'(a_1)(x-a_1) + f(a_1).
 \]
 Now $\l_1(a_2) = 0$ when
 \[


### PR DESCRIPTION
Seems like l_1(x) was left as a copy/paste typo of l_0(x).
