### PR TITLE
Fix typo in p'(t) in example 11.2.2.

### DIFF
--- a/public/textbook/antiderivatives.tex
+++ b/public/textbook/antiderivatives.tex
@@ -677,7 +677,7 @@ p'(t) = -9.8t + 15.
 \]
 Now let's take the antiderivative again. 
 \begin{align*}
-\int p'(t) \d t &= \int -9.8 +15\d t\\
+\int p'(t) \d t &= \int -9.8t +15\d t\\
 p(t) &= \frac{-9.8t^2}{2} + 15t + D.
 \end{align*}
 Since we know the initial height was $2$ meters, write


### PR DESCRIPTION
A 't' was dropped in the antidifferentiation step.
