### PR TITLE
Add missing '+' in Exa. 13.1.3.

### DIFF
--- a/public/textbook/fundamentalTheoremOfCalculus.tex
+++ b/public/textbook/fundamentalTheoremOfCalculus.tex
@@ -180,7 +180,7 @@ The correct choice is $\frac{x^{10}}{10} + \ln(x)$, one could verify this by
 taking the derivative. Hence
 \begin{align*}
 \int_1^2\left(x^9 + \frac{1}{x}\right) \d x &= \left(\frac{x^{10}}{10} + \ln(x)\right)\Bigg|_1^2 \\
-&= \frac{2^{10}}{10} \ln(2) - \frac{1}{10}.
+&= \frac{2^{10}}{10} + \ln(2) - \frac{1}{10}.
 \end{align*}
 \end{solution}
 


### PR DESCRIPTION
The plus sign was dropped from the solution.
